### PR TITLE
Refactor OMDb API key retrieval 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,13 @@
-# Example environment configuration for Flick Fusion
-# Copy this file to .env and fill in your real values.
+; Example environment configuration for Flick Fusion
+; Copy this file to .env and fill in your real values.
 
-# OMDb API key used by backend/api/omdb.php
-OMDB_API_KEY=changeme
+; OMDb API key used by backend/api/omdb.php
+OMDB_API_KEY="changeme"
 
-# Database connection settings (used by backend/config/db.php)
-# Typical XAMPP/WAMP defaults shown below.
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_NAME=flick_fusion
-DB_USER=root
-DB_PASS=
+; Database connection settings (used by backend/config/db.php)
+; Typical XAMPP/WAMP defaults shown below.
+DB_HOST="127.0.0.1"
+DB_PORT="3306"
+DB_NAME="flick_fusion"
+DB_USER="root"
+DB_PASS=""

--- a/backend/api/omdb.php
+++ b/backend/api/omdb.php
@@ -2,10 +2,27 @@
 // backend/api/omdb.php
 // This handles OMDb API connections (movie data fetching)
 
-// 1️Return your OMDb API key
-function omdb_api_key(): string {
- 
-  return '6754e3a3';
+// 1️Return your OMDb API key from the .env file
+function omdb_api_key(): ?string {
+  // Path to the .env file at the project root
+  $envPath = __DIR__ . '/../../.env';
+
+  if (!file_exists($envPath)) {
+    // .env file does not exist, log an error
+    error_log('Security Notice: .env file not found. Cannot load OMDb API key.');
+    return null;
+  }
+
+  // Parse the .env file
+  $env = parse_ini_file($envPath);
+
+  if (empty($env['OMDB_API_KEY'])) {
+    // OMDB_API_KEY is not set in the .env file, log an error
+    error_log('Configuration Error: OMDB_API_KEY not found in .env file.');
+    return null;
+  }
+
+  return $env['OMDB_API_KEY'];
 }
 
 // Search movies by title


### PR DESCRIPTION
Refactor OMDb API key retrieval to load from .env file and add error logging for missing configurations. Modified .env.example so it works properly if copied over.